### PR TITLE
FIX: Reverting back to req.body

### DIFF
--- a/backend/src/routes/parentSignupRoute.js
+++ b/backend/src/routes/parentSignupRoute.js
@@ -24,8 +24,8 @@ router.post("/signup", (req, res) => {
 
 router.post("/login", (req, res) => {
   console.log("PARENT LOGIN REQUEST");
-  const email = req.query.email;
-  const password = req.query.password;
+  const email = req.body.email;
+  const password = req.body.password;
 
   return parent
     .login(email, password)


### PR DESCRIPTION
Accidentally swapped to req.query instead of req.body for the parent login endpoint