### PR TITLE
Obtain User IDs from JWT Token

### DIFF
--- a/backend/src/controllers/adminAuthController.js
+++ b/backend/src/controllers/adminAuthController.js
@@ -34,8 +34,8 @@ export default class adminAuthController {
               if (result) {
                 const token = jwt.sign(
                   {
-                    email: email,
                     role: "admin",
+                    userId: userId,
                   },
                   process.env.JWT_SECRET,
                   {
@@ -45,9 +45,6 @@ export default class adminAuthController {
                 );
 
                 resolve({
-                  email: email,
-                  role: "admin",
-                  userId: userId,
                   token: token,
                 });
               } else {

--- a/backend/src/controllers/parentAuthController.js
+++ b/backend/src/controllers/parentAuthController.js
@@ -33,8 +33,8 @@ export default class parentAuthController {
               if (result) {
                 const token = jwt.sign(
                   {
-                    email: email,
                     role: "guardian",
+                    userId: userId,
                   },
                   process.env.JWT_SECRET,
                   {
@@ -44,9 +44,6 @@ export default class parentAuthController {
                 );
 
                 resolve({
-                  email: email,
-                  role: "guardian",
-                  userId: userId,
                   token: token,
                 });
               } else {

--- a/backend/src/routes/adminAuthRoute.js
+++ b/backend/src/routes/adminAuthRoute.js
@@ -39,4 +39,20 @@ router.post("/login", (req, res) => {
       res.status(500).send("Login failed");
     });
 });
+
+router.post("/testing-auth-middleware", authorize("Admin"), (req, res) => {
+  console.log("TESTING ADMIN AUTH MIDDLEWARE");
+
+  /*
+    FOR FUTURE REFERENCE:
+    -> When using authorize middleware, we can use req.auth to get content from token
+  */
+
+  res
+    .status(200)
+    .send(
+      `Authorized ${req.body.email} with user ID: ${req.auth.userId} and role: ${req.auth.role}`
+    );
+});
+
 export default router;

--- a/backend/src/routes/parentSignupRoute.js
+++ b/backend/src/routes/parentSignupRoute.js
@@ -41,10 +41,19 @@ router.post("/login", (req, res) => {
     });
 });
 
-router.post("/testing-auth-middleware", authorize("Tutor"), (req, res) => {
+router.post("/testing-auth-middleware", authorize("Guardian"), (req, res) => {
   console.log("TESTING AUTH MIDDLEWARE");
 
-  res.status(200).send(`Authorized with ${email} and ${password}`);
+  /*
+    FOR FUTURE REFERENCE:
+    -> When using authorize middleware, we can use req.auth to get content from token
+  */
+
+  res
+    .status(200)
+    .send(
+      `Authorized ${req.body.email} with user ID: ${req.auth.userId} and role: ${req.auth.role}`
+    );
 });
 
 export default router;

--- a/backend/src/routes/parentSignupRoute.js
+++ b/backend/src/routes/parentSignupRoute.js
@@ -42,7 +42,7 @@ router.post("/login", (req, res) => {
 });
 
 router.post("/testing-auth-middleware", authorize("Guardian"), (req, res) => {
-  console.log("TESTING AUTH MIDDLEWARE");
+  console.log("TESTING GUARDIAN AUTH MIDDLEWARE");
 
   /*
     FOR FUTURE REFERENCE:

--- a/frontend/src/components/LoginForm/index.js
+++ b/frontend/src/components/LoginForm/index.js
@@ -31,8 +31,6 @@ const LoginForm = () => {
       }
     );
 
-    localStorage.setItem("email", response.data.email);
-    localStorage.setItem("role", response.data.role);
     localStorage.setItem("token", response.data.token);
   };
 


### PR DESCRIPTION
Rather than saving userId, email, etc. in local storage (which could be easily modified), there are a few changes:

- JWT token now has `role` and `userId` in the token's payload
- Only token is saved in local storage
- `role` and `userId` can then be **_retrieved_** in endpoints (that use the `authorize()` middleware) by accessing `req.auth`