### PR TITLE
update parent and tutor dashboard frontend layout

### DIFF
--- a/frontend/src/components/Banner/index.css
+++ b/frontend/src/components/Banner/index.css
@@ -53,6 +53,12 @@ img {
   font-size: 2.6vw;
 }
 
+.banner-subtitle {
+  padding-top: 10px;
+  padding-bottom: 10px;
+  white-space: pre-line;
+}
+
 @media screen and (max-width: 750px) {
   .right-shape {
     height: 0;

--- a/frontend/src/components/Banner/index.js
+++ b/frontend/src/components/Banner/index.js
@@ -3,7 +3,7 @@ import LeftShape from "../../assets/leftBannerShape.png";
 import RightShape from "../../assets/rightBannerShape.png";
 import CodeBuddy from "../../assets/CodeBuddyWhiteOutline.png";
 
-const Banner = ({ smallText, mainText }) => {
+const Banner = ({ smallText, mainText, smallTextBelow }) => {
   return <div className="banner-container">
     <img src={LeftShape} className="left-shape" />
     <img src={RightShape} className="right-shape" />
@@ -11,6 +11,7 @@ const Banner = ({ smallText, mainText }) => {
     <div className="banner-text-container">
       <p className="banner-subtitle">{smallText}</p>
       <h1 className="banner-title">{mainText}</h1>
+      {smallTextBelow && <p className="banner-subtitle">{smallTextBelow}</p>}
     </div>
   </div>;
 };

--- a/frontend/src/components/Header/index.css
+++ b/frontend/src/components/Header/index.css
@@ -21,6 +21,14 @@
   object-fit: contain;
 }
 
+
+.header-logout {
+  height: 85%;
+  width: 100%;
+  object-fit: contain;
+  margin-left: 94vw;
+}
+
 .navbar {
   list-style-type: none;
   margin: 0;

--- a/frontend/src/components/Header/index.js
+++ b/frontend/src/components/Header/index.js
@@ -1,12 +1,14 @@
 import { NavLink } from 'react-router-dom';
 import "./index.css";
 import logo from "../../assets/CompressedBlackLogo.png";
+import Logout from "../../assets/logout.png";
 
 const Header = (props) => {
   return (
     <div className="header-container">
       <div className="header-logo-container">
         <img src={logo} className="header-logo" />
+        <img src={Logout} alt="Logout" className="header-logout"/>
       </div>
       <nav>
         {props.nav}

--- a/frontend/src/components/ParentDashboardLayout/index.css
+++ b/frontend/src/components/ParentDashboardLayout/index.css
@@ -8,29 +8,21 @@
 }
 
 .main-row {
-    height: 100%;
+    display: grid;
+    grid-template-columns: 15% 85%;
 }
 
 h2 {
     font-size: 1.4rem; 
 }
 
-.column {
-    float: left;
-}
-
 .left-span {
-    width: 15%;
-    box-sizing: border-box;
     background-color: #103DA2;
-    padding: .7rem 1rem;
-    color: white;
-    height: 100vh;
+    box-sizing: border-box;
   }
 
 
 .middle-right {
-    width: 83%;
     display: flex;
     flex-direction: column;
 }
@@ -83,26 +75,12 @@ h2 {
     height: 3px;
 }
 
-.right-container {
-    box-sizing: border-box;
-    padding: 0 1rem;
-    color: white;
-    background-color: #103DA2;
-    height: 15rem;
-    margin: 0 .5rem;
-    margin-top: .5rem;
-    border-radius: 15px;
-    border: none;
-}
 
 .left-header,
 .right-header {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    font-weight: bold;
-    max-width: 100%;
     flex-direction: column;
+    justify-content: space-between;
 }
 
 .right-buttons {
@@ -129,15 +107,12 @@ h2 {
     padding-right: 2.5rem;
 }
 
-.inner-left {
-    width: 80%;
+.inner-row {
+    display: grid;
+    grid-template-columns: 75% 25%;
 }
 
-.inner-right {
-    width: 20%;
-    display: flex;
-    flex-direction: column;
-}
+
 
 .table-of-contents {
     text-align: left; /* Left-align the text */

--- a/frontend/src/components/ParentDashboardLayout/index.css
+++ b/frontend/src/components/ParentDashboardLayout/index.css
@@ -7,8 +7,12 @@
     font-family: 'Open Sans', sans-serif;
 }
 
+.main-row {
+    height: 100%;
+}
+
 h2 {
-    font-size: 1.4rem;
+    font-size: 1.4rem; 
 }
 
 .column {
@@ -16,12 +20,13 @@ h2 {
 }
 
 .left-span {
-    width: 17%;
+    width: 15%;
     box-sizing: border-box;
-    height: 100vh;
     background-color: #103DA2;
     padding: .7rem 1rem;
-}
+    color: white;
+    height: 100vh;
+  }
 
 
 .middle-right {
@@ -97,6 +102,7 @@ h2 {
     align-items: center;
     font-weight: bold;
     max-width: 100%;
+    flex-direction: column;
 }
 
 .right-buttons {
@@ -158,5 +164,34 @@ h2 {
 .profile-pic {
     height: 100px;
     text-align: left; /* Left-align the text */
-    margin: 30px 25px;
+    margin-top: 2rem;
 }
+
+/*indenting the sublinks*/
+ul li ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    margin-left: 1rem; /* Adjust the indentation as needed */
+  }
+  
+  ul li ul li {
+    margin-left: 0.5rem; /* Adjust the indentation as needed */
+    font-size: .8rem
+  }
+
+  ul li:hover > ul {
+    display: block;
+  }
+
+  .children-sublinks {
+    display: none;
+  }
+
+  .courses-sublinks {
+    display: none;
+  }
+
+  .tutor-sublinks {
+    display: none;
+  }

--- a/frontend/src/components/ParentDashboardLayout/index.js
+++ b/frontend/src/components/ParentDashboardLayout/index.js
@@ -5,7 +5,7 @@ import { NavLink } from "react-router-dom";
 
 import "./index.css";
 
-export const ParentDashboardLayout = (props) => {
+export const ParentDashboardLayout = (props) => { 
     // Function to toggle the visibility of the Children sublinks
     const toggleChildrenDropdown = () => {
         const childrenSublinks = document.querySelector(".children-sublinks");
@@ -25,15 +25,14 @@ export const ParentDashboardLayout = (props) => {
       };
     return (
         <div className="page-container">
-            <Header
-            />
+            <Header/>
             <div class="main-row">
 
                 <div class="column left-span">
                     <div class="left-header">
                         <img className="profile-pic"
                             src={ProfilePic} />
-                        <p>Adam Bennet</p>
+                        <p>Adam Bennett</p>
                     </div>
                     
                     <div className="table-of-contents">
@@ -63,22 +62,22 @@ export const ParentDashboardLayout = (props) => {
                         </ul>
                     </div>
                 </div>
-                <div>
-                    <div class="column middle-right">
-                        <Banner
-                            smallText="Parent Dashboard"
-                            mainText="Welcome Back!"
-                        />
-                        <div className="inner-row">
-                            <div className="column inner-left">
-                                {props.children}
-                            </div>
-                            <div className="column inner-right">
-                                {props.rightColumnContent}
-                            </div>
+
+                <div class="column middle-right">
+                    <Banner
+                        smallText="Parent Dashboard"
+                        mainText="Welcome Back!"
+                    />
+                    <div className="inner-row">
+                        <div className="column inner-left">
+                            {props.children}
+                        </div>
+                        <div className="column inner-right">
+                            {props.rightColumnContent}
                         </div>
                     </div>
                 </div>
+
             </div>
         </div>
     );

--- a/frontend/src/components/ParentDashboardLayout/index.js
+++ b/frontend/src/components/ParentDashboardLayout/index.js
@@ -1,16 +1,28 @@
 import Header from "../Header";
 import Banner from "../Banner";
-import SearchBar from "../SearchBar";
-import AddStudentForm from "../AddStudentForm";
-import Plus from "../../assets/plus.png";
 import ProfilePic from "../../assets/parentProfile.png"
-import Notification from "../../assets/notifications.png";
-import Bag from "../../assets/bag.png";
-import { NavLink } from "react-router-dom";
+import { NavLink } from "react-router-dom"; 
 
 import "./index.css";
 
 export const ParentDashboardLayout = (props) => {
+    // Function to toggle the visibility of the Children sublinks
+    const toggleChildrenDropdown = () => {
+        const childrenSublinks = document.querySelector(".children-sublinks");
+        childrenSublinks.style.display = childrenSublinks.style.display === "block" ? "none" : "block";
+        };
+
+    // Function to toggle the visibility of the Courses sublinks
+    const toggleCoursesDropdown = () => {
+      const coursesSublinks = document.querySelector(".courses-sublinks");
+      coursesSublinks.style.display = coursesSublinks.style.display === "block" ? "none" : "block";
+    };
+
+    // Function to toggle the visibility of the Tutor sublinks
+    const toggleTutorSublinks = () => {
+        const tutorSublinks = document.querySelector(".tutor-sublinks");
+        tutorSublinks.style.display = tutorSublinks.style.display === "block" ? "none" : "block";
+      };
     return (
         <div className="page-container">
             <Header
@@ -19,28 +31,33 @@ export const ParentDashboardLayout = (props) => {
 
                 <div class="column left-span">
                     <div class="left-header">
-                        <button class="header-button">Upcoming Classes</button>
-                        <div class="right-buttons">
-                            <button class="header-button-round">
-                                <img className="plusImage" src={Plus} alt="Plus" />
-                            </button>
-                            <button class="header-button-round">
-                                <img
-                                    className="notificationsImage"
-                                    src={Notification}
-                                    alt="Notification"
-                                />
-                            </button>
-                        </div>
+                        <img className="profile-pic"
+                            src={ProfilePic} />
+                        <p>Adam Bennet</p>
                     </div>
-                    <img className="profile-pic"
-                        src={ProfilePic} />
+                    
                     <div className="table-of-contents">
                         <ul>
-                            <li><a href="/parentDash">Adam Bennett</a></li>
-                            <li><a href="/parentDash">Children</a></li>
-                            <li><a href="/shop">Courses</a></li>
-                            <li><a href="#">Tutors</a></li>
+                            <li>
+                            <a href="#" onClick={toggleChildrenDropdown}>Children</a>
+                            <ul className="children-sublinks">
+                                <li><a href="#">Alex Bennett</a></li>
+                                <li><a href="#">Laura Bennett</a></li>
+                            </ul>
+                            </li>
+                            <li>
+                            <a href="#" onClick={toggleCoursesDropdown}>Courses</a>
+                            <ul className="courses-sublinks">
+                                <li><a href="#">Java</a></li>
+                                <li><a href="#">Python</a></li>
+                            </ul>
+                            </li>
+                            <li>
+                            <a href="#" onClick={toggleTutorSublinks}>Tutors</a>
+                            <ul className="tutor-sublinks">
+                                <li><a href="#">Jasmine May</a></li>
+                            </ul>
+                            </li>
                             <li><a href="#">Settings</a></li>
                             <li><a href="#">Help</a></li>
                         </ul>

--- a/frontend/src/components/TutorDashboardLayout/index.css
+++ b/frontend/src/components/TutorDashboardLayout/index.css
@@ -16,10 +16,10 @@ h2 {
 }
 
 .left {
-    width: 17%;
+    width: 15%;
     box-sizing: border-box;
     height: 100vh;
-    background-color: #00B0F1;
+    background-color: #103DA2;
     padding: .7rem 1rem;
 }
 
@@ -107,6 +107,7 @@ h2 {
     align-items: center;
     font-weight: bold;
     max-width: 100%;
+    color: white;
 }
 
 .right-buttons {
@@ -132,3 +133,24 @@ h2 {
 .shop-courses {
     padding-right: 2.5rem;
 }
+
+/*indenting the sublinks*/
+ul li ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    margin-left: 1rem; /* Adjust the indentation as needed */
+  }
+  
+  ul li ul li {
+    margin-left: 0.5rem; /* Adjust the indentation as needed */
+    font-size: .8rem
+  }
+
+  ul li:hover > ul {
+    display: block;
+  }
+
+  .courses-sublinks {
+    display: none;
+  }

--- a/frontend/src/components/TutorDashboardLayout/index.css
+++ b/frontend/src/components/TutorDashboardLayout/index.css
@@ -11,32 +11,24 @@ h2 {
     font-size: 1.4rem;
 }
 
-.column {
-    float: left;
+.main-tutor-row {
+    display: grid;
+    grid-template-columns: 15% 65% 20%;
 }
 
 .left {
-    width: 15%;
-    box-sizing: border-box;
-    height: 100vh;
     background-color: #103DA2;
-    padding: .7rem 1rem;
 }
 
-.right {
-    width: 17%;
-}
 
 .middle {
-    width: 64%;
     display: flex;
-    flex-direction: column;
+    flex-direction: column; 
 }
 
 .right-middle {
-    width: 81%;
     display: flex;
-    flex-direction: column;
+    flex-direction: column; 
 }
 
 

--- a/frontend/src/components/TutorDashboardLayout/index.js
+++ b/frontend/src/components/TutorDashboardLayout/index.js
@@ -13,7 +13,7 @@ export const TutorDashboardLayout = ({ name, rightColumnContent, ...props }) => 
     const toggleCoursesDropdown = () => {
       const coursesSublinks = document.querySelector(".courses-sublinks");
       coursesSublinks.style.display = coursesSublinks.style.display === "block" ? "none" : "block";
-    };
+    }; 
 
   return (
 
@@ -30,7 +30,7 @@ export const TutorDashboardLayout = ({ name, rightColumnContent, ...props }) => 
         mainText={`Welcome ${displayName}!`}
         smallTextBelow={`Start date: July 20th, 2023${'\u00A0'.repeat(5)}End Date: July 20th, 2023`} //todo connect
       />
-      <div class="main-row">
+      <div class="main-tutor-row">
         <div class="column left">
           <div class="left-header">
                 <img className="profile-pic"

--- a/frontend/src/components/TutorDashboardLayout/index.js
+++ b/frontend/src/components/TutorDashboardLayout/index.js
@@ -1,14 +1,20 @@
 import Header from "../Header";
 import Banner from "../Banner";
-import Plus from "../../assets/plus.png";
-import Notification from "../../assets/notifications.png";
-import Logout from "../../assets/logout.png";
 import { NavLink } from "react-router-dom";
+import ProfilePic from "../../assets/parentProfile.png"
 
-import "./index.css";
+import "./index.css"; 
+
 
 export const TutorDashboardLayout = ({ name, rightColumnContent, ...props }) => {
   let displayName = name !== undefined ? " Back, " + name : "";
+
+    // Function to toggle the visibility of the Courses sublinks
+    const toggleCoursesDropdown = () => {
+      const coursesSublinks = document.querySelector(".courses-sublinks");
+      coursesSublinks.style.display = coursesSublinks.style.display === "block" ? "none" : "block";
+    };
+
   return (
 
     <div className="page-container">
@@ -21,35 +27,34 @@ export const TutorDashboardLayout = ({ name, rightColumnContent, ...props }) => 
       </ul>} />
       <Banner
         smallText={props.smallText || "Tutor Dashboard"}
-        mainText={`Welcome${displayName}!`}
+        mainText={`Welcome ${displayName}!`}
+        smallTextBelow={`Start date: July 20th, 2023${'\u00A0'.repeat(5)}End Date: July 20th, 2023`} //todo connect
       />
       <div class="main-row">
         <div class="column left">
           <div class="left-header">
-            <button class="header-button">Upcoming Classes</button>
-            <div class="right-buttons">
-              <button class="header-button-round">
-                <img className="plusImage" src={Plus} alt="Plus" />
-              </button>
-              <button class="header-button-round">
-                <img
-                  className="notificationsImage"
-                  src={Notification}
-                  alt="Notification"
-                />
-              </button>
-
-              <button
-                class="header-button-round"
-                onClick={() => {
-                  localStorage.clear();
-                  window.location.href = '/tutor/login';
-                }}
-              >
-                <img src={Logout} alt="Logout" />
-              </button>
+                <img className="profile-pic"
+                    src={ProfilePic} />
+                <p>Jasmine May</p>
             </div>
-          </div>
+            
+            <div className="table-of-contents">
+                <ul>
+                    <li><a href="/parentDash">Dashboard</a></li>
+                    <li><a href="/shop">Schedule</a></li>
+                    <li><a href="#">Settings</a></li>
+                    <li><a href="#">Help</a></li>
+                    <li>
+                      <a href="#" onClick={toggleCoursesDropdown}>Courses</a>
+                      <ul className="courses-sublinks">
+                        <li><a href="#">Advanced Java</a></li>
+                        <li><a href="#">Beginner Java</a></li>
+                      </ul>
+                    </li>
+                </ul>
+
+
+            </div>
         </div>
 
         <div class={rightColumnContent ? "column middle" : "column right-middle"}>{props.children}</div>


### PR DESCRIPTION
<img width="1434" alt="Screenshot 2024-02-25 at 3 37 53 PM" src="https://github.com/ubclaunchpad/ClassSync/assets/105069660/cd9958c3-1dd4-4c39-b038-7f3372c36c33">
<img width="1427" alt="Screenshot 2024-02-25 at 3 50 21 PM" src="https://github.com/ubclaunchpad/ClassSync/assets/105069660/8e44f546-bad0-448b-a892-a80952d2c761">

Updating the dashboard layout with new design for sidebar. Links for list of children/tutors/courses are shown upon hovering the respective navigation link.